### PR TITLE
Add Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This guide contains best practices for building great experiences and writing sustainable code using Apple's UX Frameworks. Guidance here comes from a combination of our collective practical experiences and documentation from Apple and other 3rd parties. This is meant to be a living document and all contents are perpetually open for debate and improvement.
 
+## Table of Contents
+
+* [Layout](Layout.md)
+* [Storyboards and Xibs](StoryboardsAndXibs.md)
+* [View Controllers](ViewControllers.md)
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a


### PR DESCRIPTION
Now that we're publishing via github pages to https://microsoft.github.io/apple-ux-guide/, the landing page (generated from the README) should provide a table of contents for easy navigation to the relevant guidelines.