### PR TITLE
Fix code block syntax highlighting

### DIFF
--- a/Layout.md
+++ b/Layout.md
@@ -13,13 +13,13 @@ Using [AutoLayout](https://developer.apple.com/library/archive/documentation/Use
 
 ### Examples
 
-```Swift
+```swift
 // Good: Auto Layout will properly mirror the layout for right-to-left languages
 NSLayoutConstraint.activate([subview.leadingAnchor.constraint(equalTo: superview.leadingAnchor,
                                                              constant: leadingPadding)])
 ```
 
-```Swift
+```swift
 // Bad: Frame-based layout requires special computation for right-to-left languages
 let superviewSize = superview.bounds.size
 let subviewOriginX = traitCollection.layoutDirection == .rightToLeft


### PR DESCRIPTION
Jekyll's default syntax highlighter rouge recognizes `swift` as a language, but doesn't recognize `Swift`. Change the casing to fix the issue on the deployed website.