### PR TITLE
Initial SwiftUI conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This guide contains best practices for building great experiences and writing su
 * [Storyboards and Xibs](StoryboardsAndXibs.md)
 * [View Controllers](ViewControllers.md)
 * [Keyboard Focus](KeyboardFocus.md)
+* [SwiftUI](SwiftUI.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ This guide contains best practices for building great experiences and writing su
 ## Table of Contents
 
 * [iOS Image File Format](iOSImageFileFormat.md)
+* [Keyboard Focus](KeyboardFocus.md)
 * [Layout](Layout.md)
 * [Storyboards and Xibs](StoryboardsAndXibs.md)
-* [View Controllers](ViewControllers.md)
-* [Keyboard Focus](KeyboardFocus.md)
 * [SwiftUI](SwiftUI.md)
+* [View Controllers](ViewControllers.md)
 
 ## Contributing
 

--- a/SwiftUI.md
+++ b/SwiftUI.md
@@ -1,0 +1,61 @@
+# SwiftUI
+
+## GeometryReader
+
+### Convention
+Avoid using [`GeometryReaders`](https://developer.apple.com/documentation/swiftui/geometryreader) in your main view tree. To measure views, place `GeometryReaders` inside of a `.background` or `.overlay` and communicate the size up through a `Preference` or other methods.
+
+### Rationale
+`GeometryReaders` always fill all of their proposed size, essentially overriding the layout behavior of the views they wrap. They also override the children's ideal size.
+
+Usage of `.background` or `.overlay` is recommended because the content of these modifiers doesn't affect the layout of the parent view, so this limits the GR's impact while still allowing you to measure the parent view final size (note this can be different from the proposed size).
+
+### Example
+```swift
+// Good: Measure final size of Text without affecting its layout
+Text("Sample text")
+    .background { // Size proposed to this will be the final size of the Text view
+        GeometryReader { proxy in
+            Color.clear.preference(key: SizePreferenceKey.self, value: proxy.size)
+        }
+    }
+    .onPreferenceChange(SizePreferenceKey.self) { size in
+        // Do things with the measured size
+    }
+
+private struct SizePreferenceKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
+    }
+}
+```
+
+```swift
+// Bad: We measure size proposed to the Text view, but the GeometryReader won't fit the text. 
+GeometryReader { proxy in 
+    Text("Sample text")
+}
+```
+
+### Exceptions
+There are cases where you may need to read the size proposed to a view, instead of the final size (for example to do custom proportional layout). In these cases, first consider if a combination of stacks, spacers and frames can be used instead.
+
+If you absolutely need the `GeometryReader`, expanding to fill the dimension you want to measure is unavoidable. You can still limit the impact using a few of these methods:
+- Wrap the `GeometryReader` in a frame, constraining the dimension you don't care about.
+- Place the geometry reader in a `ZStack`. Combined with the previous method, this can help you measure without affecting the layout of other views in the `ZStack`. Note this will still cause the `ZStack` to fill the dimension you're measuring.
+
+## Multiline `UILabel` representables
+### Convention
+Use native `Text` instead of `UILabel` representable whenever possible.
+
+### Rationale
+SwiftUI-UIKit layout bridging is heavily dependent on `intrinsicContentSize`. `UILabel` calculates this size in a special way, taking its `preferredMaxLayoutWidth` into consideration to determine how many lines the label will need. In an Auto Layout environment this property is set automatically, but it won't be set by SwiftUI. This results in incorrect sizing for multiline `UILabels` when used in SwiftUI. The native `Text` doesn't suffer from these problems and takes the proposed width into consideration during a layout pass.
+
+### Exceptions
+There are cases where the use of `UILabel` is unavoidable, for example attributed text, which has only been supported in SwiftUI since iOS 15. In these cases you need to ensure `preferredMaxLayoutWidth` is set to the correct value. There are multiple methods of doing this:
+- in static width cases, you can directly set the property in your representable
+- if width is dynamic, you'll need to pass it down to your representable from the SwiftUI context
+    - if the width is manually computed, you can pass it as a `@Binding`, making sure to update the `UILabel` in the representable's `updateUIView` function.
+    - if the width follows from a SwiftUI layout pass, you might need to use a `GeometryReader` to measure the relevant views. See the `GeometryReader` sections for details.

--- a/SwiftUI.md
+++ b/SwiftUI.md
@@ -45,14 +45,14 @@ There are cases where you may need to read the size proposed to a view instead o
 If you absolutely need the `GeometryReader`, expanding to fill the dimension you want to measure is unavoidable.
 
 #### Example 1
-Let's say you want to ensure a view's width is always 0.65x of the proposed width and the height is fixed at 20pts.
+Let's say you want to ensure a view's width is always 0.65x of the proposed width and the height is self sized.
 
 Wrap a `GeometryReader` in a frame, constraining the dimension you don't care about.
 ```swift
 GeometryReader { proxy in 
     ...
 }
-.frame(height: 0) // The GeometryReader will only take the proposed width.
+.frame(height: 0) // The GeometryReader won't fill all proposed height
 ```
 Note that if you place your content inside of this `GeometryReader`, as far as the `GeometryReader`'s parent is concerned, the height will always be 0. This can cause layout issues because the inner view will render out of bounds.
 ```swift
@@ -63,13 +63,13 @@ GeometryReader { proxy in
 }
 .frame(height: 0)
 ```
-The core issue is that the `GeometryReader` essentially erases the layout behavior of its content. To solve this, you can place the `GeometryReader` in a `ZStack` and bubble up the measurement. Combined with the previous method, this means:
+This is caused by the `.frame` we used to constrain the `GeometryReader` to 0 height. To get the benefits of a height-constrained `GeometryReader` and a correctly sized content view, you can place the `GeometryReader` in a `ZStack` and bubble up its measurement. Combined with the previous method, this means:
 - you measure the proposed width
 - you avoid taking up all of the proposed height
 - the height proposed to the content view is untouched
 - the height returned by the content view is untouched
 
-Note this will still cause the `ZStack` to fill the proposed width. This is unavoidable if we want to measure it.
+Note that a `ZStack` will match the size of its largest child in each dimension, so it will still fill all width due to the contained `GeometryReader`.
 ```swift
 // The Rectangle will have a width proportional to the proposed width without taking up all the proposed height.
 // This is a two pass layout

--- a/SwiftUI.md
+++ b/SwiftUI.md
@@ -45,7 +45,7 @@ There are cases where you may need to read the size proposed to a view instead o
 If you absolutely need the `GeometryReader`, expanding to fill the dimension you want to measure is unavoidable.
 
 #### Example 1
-Let's say you want to ensure a view's width is always 0.6x of the proposed width and the height is fixed at 20pts.
+Let's say you want to ensure a view's width is always 0.65x of the proposed width and the height is fixed at 20pts.
 
 Wrap a `GeometryReader` in a frame, constraining the dimension you don't care about.
 ```swift

--- a/SwiftUI.md
+++ b/SwiftUI.md
@@ -108,9 +108,9 @@ GeometryReader { proxy in
 ```
 
 
-## Multiline `UILabel` representables
+## Multiline text
 ### Convention
-Use native `Text` instead of `UILabel` representable whenever possible.
+Use native `Text` instead of a `UIViewRepresentable` containing a `UILabel` whenever possible.
 
 ### Rationale
 SwiftUI-UIKit layout bridging is heavily dependent on `intrinsicContentSize`. `UILabel` calculates this size in a special way, taking its `preferredMaxLayoutWidth` into consideration to determine how many lines the label will need. In an Auto Layout environment this property is set automatically, but it won't be set by SwiftUI. This results in incorrect sizing for multiline `UILabels` when used in SwiftUI. The native `Text` doesn't suffer from these problems and takes the proposed width into consideration during a layout pass.


### PR DESCRIPTION
I wrote down some initial conventions for SwiftUI. I put them in a generic "SwiftUI" page for now, but in the future we may split this when I write more about layout or animations.